### PR TITLE
Automated install script using python + venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,24 @@ Your Fn and Ctrl keys should now be swapped
 
 
 
-### Making the Fn Key Remap Persistent 
+### Making the Fn Key Remap Persistent
 (this section is copy pasted from ChatGPT but verified and with small adjustements)
+
+## Quick install
+
+Note that the quick install uses a python venv for to install pyusb, so this should work on immutable distros like Fedora Silverblue, Universal Blue variants, etc.
+
+```
+curl -L https://github.com/aarron-lee/thinkpad_x12_fn_switcher/raw/main/install.sh | sh
+```
+
+To uninstall, run:
+
+```
+curl -L https://github.com/aarron-lee/thinkpad_x12_fn_switcher/raw/main/uninstall.sh | sh
+```
+
+## Manual Install
 
 By default, the Fn key remapping resets after unplugging the keyboard or rebooting. To make the remap permanent, we use udev rules to trigger the remapping program (x12_fn_switcher) whenever the keyboard is connected.
 📂 Step 1: Copy the Program to the Correct Location

--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@ Because there is no option in the BIOS of the "Thinkpad" X12 to switch the FN-Ke
 
 This quickly put together repo contains the c-code to send the packet. Someone might find it useful (in my research I only found someone posting the captured packet, which at least sent me on the correct path).
 
+- [Prerequisites](#prerequisites)
+- [How To](#how-to)
+- [Making the Fn Key Remap Persistent](#Making-the-Fn-Key-Remap-Persistent)
+  - [Quick Install](#quick-install)
+  - [Manual Install](#manual-install)
+- [Disclaimer](#disclaimer)
+
 ## Prerequisites
 Prerequisites
 
@@ -59,13 +66,13 @@ Your Fn and Ctrl keys should now be swapped
 Note that the quick install uses a python venv for to install pyusb, so this should work on immutable distros like Fedora Silverblue, Universal Blue variants, etc.
 
 ```
-curl -L https://github.com/aarron-lee/thinkpad_x12_fn_switcher/raw/main/install.sh | sh
+curl -L https://github.com/manueljaeckle/thinkpad_x12_fn_switcher/raw/main/install.sh | sh
 ```
 
 To uninstall, run:
 
 ```
-curl -L https://github.com/aarron-lee/thinkpad_x12_fn_switcher/raw/main/uninstall.sh | sh
+curl -L https://github.com/manueljaeckle/thinkpad_x12_fn_switcher/raw/main/uninstall.sh | sh
 ```
 
 ## Manual Install

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,55 @@
+#/bin/bash
+
+if [ "$EUID" -eq 0 ]; then
+    echo "This script must be not be run as root, don't use sudo" >&2
+    exit 1
+fi
+
+INSTALL_LOCATION=$HOME/.local/bin/fn_switcher
+RUN_SCRIPT=$INSTALL_LOCATION/switch.sh
+
+mkdir -p $INSTALL_LOCATION
+
+cd $INSTALL_LOCATION
+
+echo "Downloading files to $INSTALL_LOCATION..."
+
+git clone --depth=1 https://github.com/aarron-lee/thinkpad_x12_fn_switcher.git
+
+echo "Initializing python venv..."
+
+python -m venv --system-site-packages venv
+
+source ./venv/bin/activate
+
+echo "pip install pyusb dependency..."
+
+pip install pyusb
+
+PYTHON_COMMAND=$INSTALL_LOCATION/venv/bin/python3
+
+cat << EOF > "$RUN_SCRIPT"
+#!/usr/bin/bash
+
+$PYTHON_COMMAND $INSTALL_LOCATION/thinkpad_x12_fn_switcher/x12_fn_switcher.py
+EOF
+
+chmod +x $RUN_SCRIPT
+
+# remove old rule if it previously existed
+sudo rm -rf /etc/udev/rules.d/99-thinkpad-fn.rules
+
+cat <<EOF >> "./99-thinkpad-fn.rules"
+ACTION=="add", ATTRS{idVendor}=="17ef", ATTRS{idProduct}=="60fe", RUN+="$RUN_SCRIPT"
+EOF
+
+sudo mv ./99-thinkpad-fn.rules /etc/udev/rules.d/99-thinkpad-fn.rules
+
+sudo chcon -u system_u -r object_r --type=bin_t $RUN_SCRIPT
+
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+
+echo "Install complete. Manually running script once since the script only runs when it's connected to the device"
+
+./$RUN_SCRIPT

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ cd $INSTALL_LOCATION
 
 echo "Downloading files to $INSTALL_LOCATION..."
 
-git clone --depth=1 https://github.com/aarron-lee/thinkpad_x12_fn_switcher.git
+git clone --depth=1 https://github.com/manueljaeckle/thinkpad_x12_fn_switcher.git
 
 echo "Initializing python venv..."
 
@@ -45,11 +45,10 @@ EOF
 
 sudo mv ./99-thinkpad-fn.rules /etc/udev/rules.d/99-thinkpad-fn.rules
 
+# handle for SE linux
 sudo chcon -u system_u -r object_r --type=bin_t $RUN_SCRIPT
 
 sudo udevadm control --reload-rules
 sudo udevadm trigger
 
-echo "Install complete. Manually running script once since the script only runs when it's connected to the device"
-
-./$RUN_SCRIPT
+echo "Install complete."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,7 @@
+#/bin/bash
+
+sudo rm -rf $HOME/.local/bin/fn_switcher
+sudo rm -rf /etc/udev/rules.d/99-thinkpad-fn.rules
+
+sudo udevadm control --reload-rules
+sudo udevadm trigger

--- a/x12_fn_switcher.py
+++ b/x12_fn_switcher.py
@@ -1,0 +1,74 @@
+import usb.core
+import usb.util
+import sys
+from time import sleep
+
+# converted from c to python via Google Gemini, with some minor manual edits to make it fully functional
+
+# Constants
+VENDOR_ID = 0x17ef  # Your VID
+PRODUCT_ID = 0x60fe  # Your PID
+HID_REQUEST_SET_REPORT = 0x09
+HID_REPORT_TYPE_OUTPUT = 0x02
+INTERFACE = 1
+TIMEOUT = 5000
+
+# Find the device
+device = usb.core.find(idVendor=VENDOR_ID, idProduct=PRODUCT_ID)
+
+if device is None:
+    sys.exit("Error: Keyboard not found")
+
+try:
+    # Check if a kernel driver is active and detach it
+    if device.is_kernel_driver_active(INTERFACE):
+        sys.stdout.write("Detaching kernel driver...\n")
+        device.detach_kernel_driver(INTERFACE)
+
+    sleep(1)
+
+    # Set the active configuration. The first one is usually what you want.
+    # sys.stdout.write("Setting configuration...\n")
+    # device.set_configuration()
+
+    # Data from Wireshark (Toggle Fn key)
+    data = bytes([0x09, 0xb4, 0x02])
+
+    # Send USB Control Transfer
+    sys.stdout.write("Sending SET_REPORT Control Transfer with wIndex=1...\n")
+
+    # libusb_control_transfer in Python equivalent
+    # bmRequestType: LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE
+    # 0x20 | 0x01 = 0x21
+    # bRequest: HID_REQUEST_SET_REPORT (0x09)
+    # wValue: (HID_REPORT_TYPE_OUTPUT << 8) | data[0] -> (0x02 << 8) | 0x09 = 0x0209
+    # wIndex: INTERFACE (1)
+    # data: data
+    # timeout: TIMEOUT
+    sys.stdout.write("ctrl transfer...\n")
+
+    bytes_sent = device.ctrl_transfer(
+        bmRequestType=0x21,
+        bRequest=HID_REQUEST_SET_REPORT,
+        wValue=(HID_REPORT_TYPE_OUTPUT << 8) | data[0],
+        wIndex=INTERFACE,
+        data_or_wLength=data,
+        timeout=TIMEOUT
+    )
+
+    sys.stdout.write(f"Control Transfer successfully sent ({bytes_sent} bytes)\n")
+
+except usb.core.USBError as e:
+    sys.stderr.write(f"Error while sending: {e}\n")
+
+finally:
+    # Reattach kernel driver if it was detached
+    if device.is_kernel_driver_active(INTERFACE) is False:
+        try:
+            device.attach_kernel_driver(INTERFACE)
+            sys.stdout.write("Re-attached kernel driver\n")
+        except usb.core.USBError as e:
+            sys.stderr.write(f"Could not re-attach kernel driver: {e}\n")
+
+    # The device object will be closed automatically when it goes out of scope.
+    # However, you can also explicitly call: usb.util.dispose_resources(device)


### PR DESCRIPTION
Quick install script that uses a python venv to install pyusb

By using a python venv for dependencies, this install method is friendly to immutable distros like Fedora Silverblue, Universal Blue, Bazzite, etc. This should also work on any traditional distro that has python built in.

Distro Tested on: Bazzite 42.

original code ported to python using Google Gemini.