### PR TITLE
Python implementation of fn switcher + quick install

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@ Because there is no option in the BIOS of the "Thinkpad" X12 to switch the FN-Ke
 
 This quickly put together repo contains the c-code to send the packet. Someone might find it useful (in my research I only found someone posting the captured packet, which at least sent me on the correct path).
 
+- [Prerequisites](#prerequisites)
+- [How To](#how-to)
+- [Making the Fn Key Remap Persistent](#Making-the-Fn-Key-Remap-Persistent)
+  - [Quick Install](#quick-install)
+  - [Manual Install](#manual-install)
+- [Disclaimer](#disclaimer)
+
 ## Prerequisites
 Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ Your Fn and Ctrl keys should now be swapped
 Note that the quick install uses python and all dependencies are provided, so this should work on immutable distros like Fedora Silverblue, Universal Blue variants, etc.
 
 ```
-curl -L https://github.com/aarron-lee/thinkpad_x12_fn_switcher/raw/main/install.sh | sh
+curl -L https://github.com/manueljaeckle/thinkpad_x12_fn_switcher/raw/main/install.sh | sh
 ```
 
 To uninstall, run:
 
 ```
-curl -L https://github.com/aarron-lee/thinkpad_x12_fn_switcher/raw/main/uninstall.sh | sh
+curl -L https://github.com/manueljaeckle/thinkpad_x12_fn_switcher/raw/main/uninstall.sh | sh
 ```
 
 ## Manual Install

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Your Fn and Ctrl keys should now be swapped
 
 ## Quick install
 
-Note that the quick install uses a python venv for to install pyusb, so this should work on immutable distros like Fedora Silverblue, Universal Blue variants, etc.
+Note that the quick install uses python and all dependencies are provided, so this should work on immutable distros like Fedora Silverblue, Universal Blue variants, etc.
 
 ```
 curl -L https://github.com/aarron-lee/thinkpad_x12_fn_switcher/raw/main/install.sh | sh
@@ -138,3 +138,7 @@ sudo udevadm trigger
 ChatGPT helped me with the c stuff as I am not very familiar with hid and usb.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND...
+
+## Attribution
+
+Vendored dependency: https://github.com/apmorton/pyhidapi

--- a/README.md
+++ b/README.md
@@ -51,8 +51,24 @@ Your Fn and Ctrl keys should now be swapped
 
 
 
-### Making the Fn Key Remap Persistent 
+### Making the Fn Key Remap Persistent
 (this section is copy pasted from ChatGPT but verified and with small adjustements)
+
+## Quick install
+
+Note that the quick install uses a python venv for to install pyusb, so this should work on immutable distros like Fedora Silverblue, Universal Blue variants, etc.
+
+```
+curl -L https://github.com/aarron-lee/thinkpad_x12_fn_switcher/raw/main/install.sh | sh
+```
+
+To uninstall, run:
+
+```
+curl -L https://github.com/aarron-lee/thinkpad_x12_fn_switcher/raw/main/uninstall.sh | sh
+```
+
+## Manual Install
 
 By default, the Fn key remapping resets after unplugging the keyboard or rebooting. To make the remap permanent, we use udev rules to trigger the remapping program (x12_fn_switcher) whenever the keyboard is connected.
 📂 Step 1: Copy the Program to the Correct Location

--- a/install.sh
+++ b/install.sh
@@ -51,6 +51,4 @@ sudo chcon -u system_u -r object_r --type=bin_t $RUN_SCRIPT
 sudo udevadm control --reload-rules
 sudo udevadm trigger
 
-echo "Install complete. Manually running script once since the script only runs when the keyboard is connected"
-
-./$RUN_SCRIPT
+echo "Install complete."

--- a/install.sh
+++ b/install.sh
@@ -45,11 +45,12 @@ EOF
 
 sudo mv ./99-thinkpad-fn.rules /etc/udev/rules.d/99-thinkpad-fn.rules
 
+# handle for SE linux
 sudo chcon -u system_u -r object_r --type=bin_t $RUN_SCRIPT
 
 sudo udevadm control --reload-rules
 sudo udevadm trigger
 
-echo "Install complete. Manually running script once since the script only runs when it's connected to the device"
+echo "Install complete. Manually running script once since the script only runs when the keyboard is connected"
 
 ./$RUN_SCRIPT

--- a/install.sh
+++ b/install.sh
@@ -16,22 +16,10 @@ echo "Downloading files to $INSTALL_LOCATION..."
 
 git clone --depth=1 https://github.com/aarron-lee/thinkpad_x12_fn_switcher.git
 
-echo "Initializing python venv..."
-
-python -m venv --system-site-packages venv
-
-source ./venv/bin/activate
-
-echo "pip install pyusb dependency..."
-
-pip install pyusb
-
-PYTHON_COMMAND=$INSTALL_LOCATION/venv/bin/python3
-
 cat << EOF > "$RUN_SCRIPT"
 #!/usr/bin/bash
 
-$PYTHON_COMMAND $INSTALL_LOCATION/thinkpad_x12_fn_switcher/x12_fn_switcher.py
+python3 $INSTALL_LOCATION/thinkpad_x12_fn_switcher/x12_fn_switcher.py
 EOF
 
 chmod +x $RUN_SCRIPT

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,55 @@
+#/bin/bash
+
+if [ "$EUID" -eq 0 ]; then
+    echo "This script must be not be run as root, don't use sudo" >&2
+    exit 1
+fi
+
+INSTALL_LOCATION=$HOME/.local/bin/fn_switcher
+RUN_SCRIPT=$INSTALL_LOCATION/switch.sh
+
+mkdir -p $INSTALL_LOCATION
+
+cd $INSTALL_LOCATION
+
+echo "Downloading files to $INSTALL_LOCATION..."
+
+git clone --depth=1 https://github.com/aarron-lee/thinkpad_x12_fn_switcher.git
+
+echo "Initializing python venv..."
+
+python -m venv --system-site-packages venv
+
+source ./venv/bin/activate
+
+echo "pip install pyusb dependency..."
+
+pip install pyusb
+
+PYTHON_COMMAND=$INSTALL_LOCATION/venv/bin/python3
+
+cat << EOF > "$RUN_SCRIPT"
+#!/usr/bin/bash
+
+$PYTHON_COMMAND $INSTALL_LOCATION/thinkpad_x12_fn_switcher/x12_fn_switcher.py
+EOF
+
+chmod +x $RUN_SCRIPT
+
+# remove old rule if it previously existed
+sudo rm -rf /etc/udev/rules.d/99-thinkpad-fn.rules
+
+cat <<EOF >> "./99-thinkpad-fn.rules"
+ACTION=="add", ATTRS{idVendor}=="17ef", ATTRS{idProduct}=="60fe", RUN+="$RUN_SCRIPT"
+EOF
+
+sudo mv ./99-thinkpad-fn.rules /etc/udev/rules.d/99-thinkpad-fn.rules
+
+sudo chcon -u system_u -r object_r --type=bin_t $RUN_SCRIPT
+
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+
+echo "Install complete. Manually running script once since the script only runs when it's connected to the device"
+
+./$RUN_SCRIPT

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ cd $INSTALL_LOCATION
 
 echo "Downloading files to $INSTALL_LOCATION..."
 
-git clone --depth=1 https://github.com/aarron-lee/thinkpad_x12_fn_switcher.git
+git clone --depth=1 https://github.com/manueljaeckle/thinkpad_x12_fn_switcher.git
 
 cat << EOF > "$RUN_SCRIPT"
 #!/usr/bin/bash

--- a/thinkpad_hid.py
+++ b/thinkpad_hid.py
@@ -1,0 +1,298 @@
+# MIT License
+
+# Copyright (c) 2019 Austin Morton
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import ctypes
+import atexit
+import enum
+
+__all__ = ['HIDException', 'DeviceInfo', 'Device', 'enumerate', 'BusType']
+
+
+hidapi = None
+library_paths = (
+    'libhidapi-hidraw.so',
+    'libhidapi-hidraw.so.0',
+    'libhidapi-libusb.so',
+    'libhidapi-libusb.so.0',
+    'libhidapi-iohidmanager.so',
+    'libhidapi-iohidmanager.so.0',
+    'libhidapi.dylib',
+    'hidapi.dll',
+    'libhidapi-0.dll'
+)
+
+for lib in library_paths:
+    try:
+        hidapi = ctypes.cdll.LoadLibrary(lib)
+        break
+    except OSError:
+        pass
+else:
+    error = "Unable to load any of the following libraries:{}"\
+        .format(' '.join(library_paths))
+    raise ImportError(error)
+
+
+hidapi.hid_init()
+atexit.register(hidapi.hid_exit)
+
+
+class HIDException(Exception):
+    pass
+
+class APIVersion(ctypes.Structure):
+    _fields_ = [
+        ('major', ctypes.c_int),
+        ('minor', ctypes.c_int),
+        ('patch', ctypes.c_int),
+    ]
+
+try:
+    hidapi.hid_version.argtypes = []
+    hidapi.hid_version.restype = ctypes.POINTER(APIVersion)
+
+    version = hidapi.hid_version()
+    version = (
+        version.contents.major,
+        version.contents.minor,
+        version.contents.patch,
+    )
+except AttributeError:
+    #
+    # hid_version API was added in
+    # https://github.com/libusb/hidapi/commit/8f72236099290345928e646d2f2c48f0187ac4af
+    # so if it is missing we are dealing with hidapi 0.8.0 or older
+    #
+    version = (0, 8, 0)
+
+if version >= (0, 13, 0):
+    bus_type = [
+        ('bus_type', ctypes.c_int),
+    ]
+else:
+    bus_type = []
+
+class BusType(enum.Enum):
+    UNKNOWN = 0x00
+    USB = 0x01
+    BLUETOOTH = 0x02
+    I2C = 0x03
+    SPI = 0x04
+
+class DeviceInfo(ctypes.Structure):
+    def as_dict(self):
+        ret = {}
+        for name, type in self._fields_:
+            if name == 'next':
+                continue
+            ret[name] = getattr(self, name, None)
+
+            if name == 'bus_type':
+                ret[name] = BusType(ret[name])
+
+        return ret
+
+DeviceInfo._fields_ = [
+    ('path', ctypes.c_char_p),
+    ('vendor_id', ctypes.c_ushort),
+    ('product_id', ctypes.c_ushort),
+    ('serial_number', ctypes.c_wchar_p),
+    ('release_number', ctypes.c_ushort),
+    ('manufacturer_string', ctypes.c_wchar_p),
+    ('product_string', ctypes.c_wchar_p),
+    ('usage_page', ctypes.c_ushort),
+    ('usage', ctypes.c_ushort),
+    ('interface_number', ctypes.c_int),
+    ('next', ctypes.POINTER(DeviceInfo)),
+] + bus_type
+
+hidapi.hid_init.argtypes = []
+hidapi.hid_init.restype = ctypes.c_int
+hidapi.hid_exit.argtypes = []
+hidapi.hid_exit.restype = ctypes.c_int
+hidapi.hid_enumerate.argtypes = [ctypes.c_ushort, ctypes.c_ushort]
+hidapi.hid_enumerate.restype = ctypes.POINTER(DeviceInfo)
+hidapi.hid_free_enumeration.argtypes = [ctypes.POINTER(DeviceInfo)]
+hidapi.hid_free_enumeration.restype = None
+hidapi.hid_open.argtypes = [ctypes.c_ushort, ctypes.c_ushort, ctypes.c_wchar_p]
+hidapi.hid_open.restype = ctypes.c_void_p
+hidapi.hid_open_path.argtypes = [ctypes.c_char_p]
+hidapi.hid_open_path.restype = ctypes.c_void_p
+hidapi.hid_write.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_size_t]
+hidapi.hid_write.restype = ctypes.c_int
+hidapi.hid_read_timeout.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_size_t, ctypes.c_int]
+hidapi.hid_read_timeout.restype = ctypes.c_int
+hidapi.hid_read.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_size_t]
+hidapi.hid_read.restype = ctypes.c_int
+hidapi.hid_get_input_report.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_size_t]
+hidapi.hid_get_input_report.restype = ctypes.c_int
+hidapi.hid_set_nonblocking.argtypes = [ctypes.c_void_p, ctypes.c_int]
+hidapi.hid_set_nonblocking.restype = ctypes.c_int
+hidapi.hid_send_feature_report.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_int]
+hidapi.hid_send_feature_report.restype = ctypes.c_int
+hidapi.hid_get_feature_report.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_size_t]
+hidapi.hid_get_feature_report.restype = ctypes.c_int
+if version >= (0, 14, 0):
+    hidapi.hid_get_report_descriptor.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_size_t]
+    hidapi.hid_get_report_descriptor.restype = ctypes.c_int
+hidapi.hid_close.argtypes = [ctypes.c_void_p]
+hidapi.hid_close.restype = None
+hidapi.hid_get_manufacturer_string.argtypes = [ctypes.c_void_p, ctypes.c_wchar_p, ctypes.c_size_t]
+hidapi.hid_get_manufacturer_string.restype = ctypes.c_int
+hidapi.hid_get_product_string.argtypes = [ctypes.c_void_p, ctypes.c_wchar_p, ctypes.c_size_t]
+hidapi.hid_get_product_string.restype = ctypes.c_int
+hidapi.hid_get_serial_number_string.argtypes = [ctypes.c_void_p, ctypes.c_wchar_p, ctypes.c_size_t]
+hidapi.hid_get_serial_number_string.restype = ctypes.c_int
+hidapi.hid_get_indexed_string.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_wchar_p, ctypes.c_size_t]
+hidapi.hid_get_indexed_string.restype = ctypes.c_int
+hidapi.hid_error.argtypes = [ctypes.c_void_p]
+hidapi.hid_error.restype = ctypes.c_wchar_p
+
+
+def enumerate(vid=0, pid=0):
+    ret = []
+    info = hidapi.hid_enumerate(vid, pid)
+    c = info
+
+    while c:
+        ret.append(c.contents.as_dict())
+        c = c.contents.next
+
+    hidapi.hid_free_enumeration(info)
+
+    return ret
+
+
+class Device(object):
+    def __init__(self, vid=None, pid=None, serial=None, path=None):
+        if path:
+            self.__dev = hidapi.hid_open_path(path)
+        elif serial:
+            serial = ctypes.create_unicode_buffer(serial)
+            self.__dev = hidapi.hid_open(vid, pid, serial)
+        elif vid and pid is not None:
+            self.__dev = hidapi.hid_open(vid, pid, None)
+        else:
+            raise ValueError('specify vid/pid or path')
+
+        if not self.__dev:
+            raise HIDException('unable to open device')
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.close()
+
+    def __hidcall(self, function, *args, **kwargs):
+        if not self.__dev:
+            raise HIDException('device closed')
+
+        ret = function(*args, **kwargs)
+
+        if ret == -1:
+            err = hidapi.hid_error(self.__dev)
+            raise HIDException(err)
+        return ret
+
+    def __readstring(self, function, max_length=255):
+        buf = ctypes.create_unicode_buffer(max_length)
+        self.__hidcall(function, self.__dev, buf, max_length)
+        return buf.value
+
+    def write(self, data):
+        return self.__hidcall(hidapi.hid_write, self.__dev, data, len(data))
+
+    def read(self, size, timeout=None):
+        data = ctypes.create_string_buffer(size)
+
+        if timeout is None:
+            size = self.__hidcall(hidapi.hid_read, self.__dev, data, size)
+        else:
+            size = self.__hidcall(
+                hidapi.hid_read_timeout, self.__dev, data, size, timeout)
+
+        return data.raw[:size]
+
+    def get_input_report(self, report_id, size):
+        data = ctypes.create_string_buffer(size)
+
+        # Pass the id of the report to be read.
+        data[0] = bytearray((report_id,))
+
+        size = self.__hidcall(
+            hidapi.hid_get_input_report, self.__dev, data, size)
+        return data.raw[:size]
+
+    def send_feature_report(self, data):
+        return self.__hidcall(hidapi.hid_send_feature_report,
+                              self.__dev, data, len(data))
+
+    def get_feature_report(self, report_id, size):
+        data = ctypes.create_string_buffer(size)
+
+        # Pass the id of the report to be read.
+        data[0] = bytearray((report_id,))
+
+        size = self.__hidcall(
+            hidapi.hid_get_feature_report, self.__dev, data, size)
+        return data.raw[:size]
+
+    if version >= (0, 14, 0):
+        def get_report_descriptor(self, size = 4096):
+            data = ctypes.create_string_buffer(size)
+            size = self.__hidcall(
+                hidapi.hid_get_report_descriptor, self.__dev, data, size)
+            return data.raw[:size]
+
+    def close(self):
+        if self.__dev:
+            hidapi.hid_close(self.__dev)
+            self.__dev = None
+
+    @property
+    def nonblocking(self):
+        return getattr(self, '_nonblocking', 0)
+
+    @nonblocking.setter
+    def nonblocking(self, value):
+        self.__hidcall(hidapi.hid_set_nonblocking, self.__dev, value)
+        setattr(self, '_nonblocking', value)
+
+    @property
+    def manufacturer(self):
+        return self.__readstring(hidapi.hid_get_manufacturer_string)
+
+    @property
+    def product(self):
+        return self.__readstring(hidapi.hid_get_product_string)
+
+    @property
+    def serial(self):
+        return self.__readstring(hidapi.hid_get_serial_number_string)
+
+    def get_indexed_string(self, index, max_length=255):
+        buf = ctypes.create_unicode_buffer(max_length)
+        self.__hidcall(hidapi.hid_get_indexed_string,
+                       self.__dev, index, buf, max_length)
+        return buf.value

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,7 @@
+#/bin/bash
+
+sudo rm -rf $HOME/.local/bin/fn_switcher
+sudo rm -rf /etc/udev/rules.d/99-thinkpad-fn.rules
+
+sudo udevadm control --reload-rules
+sudo udevadm trigger

--- a/x12_fn_switcher.py
+++ b/x12_fn_switcher.py
@@ -1,0 +1,74 @@
+import usb.core
+import usb.util
+import sys
+from time import sleep
+
+# converted from c to python via Google Gemini, with some minor manual edits to make it fully functional
+
+# Constants
+VENDOR_ID = 0x17ef  # Your VID
+PRODUCT_ID = 0x60fe  # Your PID
+HID_REQUEST_SET_REPORT = 0x09
+HID_REPORT_TYPE_OUTPUT = 0x02
+INTERFACE = 1
+TIMEOUT = 5000
+
+# Find the device
+device = usb.core.find(idVendor=VENDOR_ID, idProduct=PRODUCT_ID)
+
+if device is None:
+    sys.exit("Error: Keyboard not found")
+
+try:
+    # Check if a kernel driver is active and detach it
+    if device.is_kernel_driver_active(INTERFACE):
+        sys.stdout.write("Detaching kernel driver...\n")
+        device.detach_kernel_driver(INTERFACE)
+
+    sleep(1)
+
+    # Set the active configuration. The first one is usually what you want.
+    # sys.stdout.write("Setting configuration...\n")
+    # device.set_configuration()
+
+    # Data from Wireshark (Toggle Fn key)
+    data = bytes([0x09, 0xb4, 0x02])
+
+    # Send USB Control Transfer
+    sys.stdout.write("Sending SET_REPORT Control Transfer with wIndex=1...\n")
+
+    # libusb_control_transfer in Python equivalent
+    # bmRequestType: LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE
+    # 0x20 | 0x01 = 0x21
+    # bRequest: HID_REQUEST_SET_REPORT (0x09)
+    # wValue: (HID_REPORT_TYPE_OUTPUT << 8) | data[0] -> (0x02 << 8) | 0x09 = 0x0209
+    # wIndex: INTERFACE (1)
+    # data: data
+    # timeout: TIMEOUT
+    sys.stdout.write("ctrl transfer...\n")
+
+    bytes_sent = device.ctrl_transfer(
+        bmRequestType=0x21,
+        bRequest=HID_REQUEST_SET_REPORT,
+        wValue=(HID_REPORT_TYPE_OUTPUT << 8) | data[0],
+        wIndex=INTERFACE,
+        data_or_wLength=data,
+        timeout=TIMEOUT
+    )
+
+    sys.stdout.write(f"Control Transfer successfully sent ({bytes_sent} bytes)\n")
+
+except usb.core.USBError as e:
+    sys.stderr.write(f"Error while sending: {e}\n")
+
+finally:
+    # Reattach kernel driver if it was detached
+    if device.is_kernel_driver_active(INTERFACE) is False:
+        try:
+            device.attach_kernel_driver(INTERFACE)
+            sys.stdout.write("Re-attached kernel driver\n")
+        except usb.core.USBError as e:
+            sys.stderr.write(f"Could not re-attach kernel driver: {e}\n")
+
+    # The device object will be closed automatically when it goes out of scope.
+    # However, you can also explicitly call: usb.util.dispose_resources(device)

--- a/x12_fn_switcher.py
+++ b/x12_fn_switcher.py
@@ -42,8 +42,6 @@ def main():
             print("Device Found. Writing data: {}".format([hex(d) for d in data]))
 
             hid_device.nonblocking = 1
-
-            print(f"Sending feature report with data: {[hex(d) for d in data]}")
             bytes_written = hid_device.write(bytes(data))
 
             hid_device.close()


### PR DESCRIPTION
Python implementation of the fn switcher

This implementation doesn't need to detach the kernel driver, so it fixes a potential bug where the volume buttons, brightness buttons, etc, stop working on the keyboard.

The quick install method also downloads the required python dependency, so no manual dependency install required.

Note that the quick install method won't actual work until this PR is merged, since it relies on cloning the git repo.

If you want to test it, you can run the install script from my fork:

```
curl -L https://github.com/aarron-lee/thinkpad_x12_fn_switcher/raw/main/install.sh | sh
```

To uninstall, run:

```
curl -L https://github.com/aarron-lee/thinkpad_x12_fn_switcher/raw/main/uninstall.sh | sh
```

Tested on:

x12 Detachable Gen 1, i5 16GB RAM
Distro: Bazzite 42
kernel: 6.15